### PR TITLE
chore: typo

### DIFF
--- a/src/pure.ts
+++ b/src/pure.ts
@@ -7,7 +7,7 @@ export { config } from '@vue/test-utils'
 
 const { debug, getElementLocatorSelectors } = utils
 
-type ComponentProps<T> = T extends new (...angs: any) => {
+type ComponentProps<T> = T extends new (...args: any) => {
   $props: infer P
 // eslint-disable-next-line ts/no-empty-object-type
 } ? NonNullable<P> : T extends (props: infer P, ...args: any) => any ? P : {}


### PR DESCRIPTION
BTW, I noticed that `ComponentProps` is a type from `vue-component-type-helpers`, and since `@vue/test-utils` already depends on it, perhaps we could import this type directly from `vue-component-type-helpers` as well.